### PR TITLE
Align static eyes toward center and improve mobile header layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -76,9 +76,32 @@ body{
 .eye.yellow::before{ background: var(--yellow); }
 
 .pupil{
-  position: absolute; top: 0; left: 0; width: 50%; height: 50%;
+  position: absolute;
+  top: 50%; left: 50%;
+  width: 50%; height: 50%;
   background: #000; z-index: 2;
+  transform: translate(-50%, -50%) translate(var(--tx, 0px), var(--ty, 0px));
   transition: transform .06s linear, opacity .12s ease;
 }
 
 .lid{ position:absolute; left:0; right:0; top:0; height:0%; background:#000; z-index:3; }
+
+@media (max-width: 600px){
+  #siteHeader .inner,
+  #siteFooter .inner{
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 8px 16px;
+    text-align: center;
+  }
+
+  .brand{
+    flex: 1 1 100%;
+    text-align: center;
+  }
+
+  .socials{
+    justify-content: center;
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- center the neutral pupils by default and drive them toward the screen centre
- update moving pupils to use symmetric ranges and CSS variables for translation
- tweak mobile header flex layout so the brand text is no longer truncated

## Testing
- Playwright screenshot capture (Chromium)

------
https://chatgpt.com/codex/tasks/task_e_68e6271e1968832583c2f777e05cf40c