### PR TITLE
Fix mobile truncation of ALL EYES text

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,7 +4,8 @@
   --eye-size: clamp(20px, 4.5vmin, 56px);
   --header-h: 56px;
   --footer-h: 44px;
-  --sidepair: calc(var(--eye-size) * 2);
+  --sidepair-scale: 2;
+  --sidepair: calc(var(--eye-size) * var(--sidepair-scale));
 }
 
 *{ box-sizing: border-box }


### PR DESCRIPTION
## Summary
- adjust the automatic eye sizing logic to support smaller pixels and dynamic side margins on compact screens
- expose the side-margin multiplier as a CSS variable so the script can keep the full ALL EYES mask visible

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68e6296be3ac8325a30ad59c5657cfe8