### PR TITLE
Limit desktop grid width

### DIFF
--- a/script.js
+++ b/script.js
@@ -73,6 +73,7 @@ const MASK_GAP_SPACE  = 1;
 const EYE_PX_MIN = 14;
 const EYE_PX_MIN_MOBILE = 8;
 const EYE_PX_MAX = 64;
+const GRID_MAX_WIDTH_DESKTOP = 1400;
 
 // ---------- Letters ----------
 const LINES_DESKTOP=[' ALL EYES ','ON US'];
@@ -128,6 +129,7 @@ function autoSizeEyes({ viewportWidth, usableHeight }){
   const minClamp = compact ? 2 : 3;
   const sidePairOptions = compact ? [0] : [2, 1, 0];
   const rootStyle = document.documentElement.style;
+  const maxGridWidth = compact ? Infinity : GRID_MAX_WIDTH_DESKTOP;
 
   let bestCandidate = null;
 
@@ -141,7 +143,8 @@ function autoSizeEyes({ viewportWidth, usableHeight }){
 
     for(let px = pxMax; px >= minClamp; px--){
       const sidePadding = sidePairs * 2 * px;
-      const usableW = Math.max(0, viewportWidth - sidePadding);
+      const rawUsableW = Math.max(0, viewportWidth - sidePadding);
+      const usableW = Math.min(rawUsableW, maxGridWidth);
       let cols = Math.floor(usableW / px);
       if (cols % 2 === 1) cols -= 1;
       if(cols < 2) cols = 2;

--- a/style.css
+++ b/style.css
@@ -6,6 +6,7 @@
   --footer-h: 44px;
   --sidepair-scale: 2;
   --sidepair: calc(var(--eye-size) * var(--sidepair-scale));
+  --grid-max-width: 1400px;
 }
 
 *{ box-sizing: border-box }
@@ -67,7 +68,9 @@ body{
 
 .wrap{
   position: absolute;
-  left: var(--sidepair); right: var(--sidepair); top: 0; bottom: 0;
+  left: max(var(--sidepair), calc((100% - var(--grid-max-width)) / 2));
+  right: max(var(--sidepair), calc((100% - var(--grid-max-width)) / 2));
+  top: 0; bottom: 0;
   display: grid;
   grid-template-columns: repeat(var(--cols, 10), var(--eye-size));
   grid-auto-rows: var(--eye-size);


### PR DESCRIPTION
## Summary
- cap the desktop eye grid width to avoid generating excessive columns
- center the absolute grid container while respecting the new width limit

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e6324b1bdc8325bb75caeb1760668c