### PR TITLE
Limit desktop grid height on desktop

### DIFF
--- a/script.js
+++ b/script.js
@@ -218,7 +218,12 @@ async function buildGridIncremental(){
   if (gridCols % 2 === 1) gridCols -= 1;
   wrap.style.setProperty('--cols', gridCols);
 
+  const { rows: requiredTextRows } = buildPhraseMask();
+  const hardRowCap = isMobile() ? Infinity : requiredTextRows + 12;
+
   gridRows = Math.max(2, Math.floor(usableH / eyePX));
+  gridRows = Math.max(requiredTextRows, gridRows);
+  if(gridRows > hardRowCap) gridRows = hardRowCap;
 
   const total = gridCols*gridRows;
   const batch = Math.max(50, Math.floor(total/30));


### PR DESCRIPTION
## Summary
- cap the generated grid rows on desktop to keep only six extra lines above and below the text
- ensure the grid still reserves enough rows for the phrase mask and keep it centered

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e63a8248cc83258f4abe5ecd67251f